### PR TITLE
Add Next.js configuration with Tailwind

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: false,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "kidssstoryapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "openai": "4.34.0",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.2",
+    "typescript": "5.5.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Initialize project with Next.js scripts and dependencies including React, OpenAI, zod, Tailwind and tooling.
- Configure Next.js for strict mode and disable server actions.
- Set up Tailwind CSS with PostCSS and global styles.

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689508916ad8832da349a3310178c464